### PR TITLE
fixed soql url encoder

### DIFF
--- a/src/main/scala/org/salesforce/SObject.scala
+++ b/src/main/scala/org/salesforce/SObject.scala
@@ -110,10 +110,11 @@ class SObject(sObjectN  : String, utilN: Util) {
     val util = new Util()
     val host = util.getHost()
     val baseUrl = util.getQueryUrl()
+	val sql = java.net.URLEncoder.encode(soql, "UTF-8") // need to add this function to fix the urlEncoder
 
 		val accessToken = util.getAccessToken()
 		println("accessToken: " + accessToken)
-		val url = host + baseUrl  + soql
+		val url = host + baseUrl  + sql
 		println("url: " + url)
 		val request = new HttpGet(url)
 		request.addHeader("Authorization", "Bearer " + accessToken)


### PR DESCRIPTION
Need to add this urlEncoder function to able the http request to salesforce API, or maybe you will get bad request because url bad formed. 
example: 
query = SELECT MAX (CreatedDate) FROM Case

urlEncoded = SELECT+MAX+%28CreatedDate%29+FROM+Case